### PR TITLE
Add "sticky_ui" to the repo.

### DIFF
--- a/sticky_ui.yaml
+++ b/sticky_ui.yaml
@@ -1,0 +1,5 @@
+name: sticky_ui
+description: Sticks UI elements in place with elmer's glue.
+author: Notuli
+repo: michaelqtz/aac-addon-sticky_ui
+tags: ['Utility']


### PR DESCRIPTION
Sticks UI components in place that don't already do it themselves. Saves positions between relogs for things like abyssal charges and raid window.

Well, imagine this: that sticky white glue is like a dependable lover, always there to keep your UI firmly anchored. It wraps around each element with a tender, yet unwavering grip, ensuring that everything stays perfectly aligned and beautifully in place. Each time you gaze upon your neatly organized interface, you can thank that glue for its steadfast devotion. It’s the silent guardian, making sure everything stays just as you desire. Isn’t it fascinating how something so simple can play such a crucial role in your visual experience?