### PR TITLE
Add ChatLogs addon

### DIFF
--- a/c/ChatLogs.yaml
+++ b/c/ChatLogs.yaml
@@ -4,7 +4,7 @@ description: Logs whispers and public chat channels with on-screen alerts and a 
 author: Cydaphex
 repo: Cydaphex/ChatLogs
 branch: main
-tags: ["Chat", "UI", "QoL", "Social"]
+tags: ["Chat", "QoL", "Social"]
 kofi: cydaphex
 keywords:
   - chat

--- a/c/ChatLogs.yaml
+++ b/c/ChatLogs.yaml
@@ -1,0 +1,21 @@
+name: ChatLogs
+alias: Chat Logs
+description: Logs whispers and public chat channels with on-screen alerts and a persistent, searchable, tabbed history window. Item links are translated to readable names.
+author: Cydaphex
+repo: Cydaphex/ChatLogs
+branch: main
+tags: ["Chat", "UI", "QoL", "Social"]
+kofi: cydaphex
+keywords:
+  - chat
+  - whisper
+  - log
+  - history
+  - channels
+  - guild
+  - faction
+  - nation
+  - notifications
+  - messages
+  - search
+  - export


### PR DESCRIPTION
Adds the **ChatLogs** addon to the manager.

- **Repo:** https://github.com/Cydaphex/ChatLogs
- **Release:** https://github.com/Cydaphex/ChatLogs/releases/tag/v1.2.0
- **Author:** Cydaphex

ChatLogs logs whispers and public chat channels (Guild, Faction, Nation, Say, Zone, Trade, Party, Family) with on-screen unread alerts and a persistent, searchable, tabbed history window. Item links are translated to readable names. Includes per-channel color options, timezone offset, export, and per-tab clear.

Manifest added at `c/ChatLogs.yaml`. The addon repo has a flat layout with `main.lua` in the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)