### PR TITLE
Add ChatLogs addon

### DIFF
--- a/c/ChatLogs.yaml
+++ b/c/ChatLogs.yaml
@@ -1,0 +1,21 @@
+name: ChatLogs
+alias: Chat Logs
+description: Logs whispers and public chat channels with on-screen alerts and a persistent, searchable, tabbed history window. Item links are translated to readable names.
+author: Cydaphex
+repo: Cydaphex/ChatLogs
+branch: main
+tags: ["Chat", "QoL", "Social"]
+kofi: cydaphex
+keywords:
+  - chat
+  - whisper
+  - log
+  - history
+  - channels
+  - guild
+  - faction
+  - nation
+  - notifications
+  - messages
+  - search
+  - export


### PR DESCRIPTION
﻿Adds the ChatLogs addon to the manager.

- Repo: https://github.com/Cydaphex/ChatLogs
- Release: https://github.com/Cydaphex/ChatLogs/releases/tag/v1.3.0
- Author: Cydaphex

Logs whispers and public chat channels (Guild, Faction, Nation, Say, Zone, Trade, Party, Family) with on-screen unread alerts and a persistent, searchable, tabbed history window. Item links are translated to readable names.

Manifest at c/ChatLogs.yaml; flat repo layout with main.lua in the root.
