### PR TITLE
Add TrackedTargetMarker addon

### DIFF
--- a/t/TrackedTargetMarker.yaml
+++ b/t/TrackedTargetMarker.yaml
@@ -1,0 +1,18 @@
+name: TrackedTargetMarker
+alias: Tracked Target Marker
+description: Overhead markers for the targets you track and the targets they're targeting. Independent symbol, color, and size per marker, with a draggable toggle button.
+author: Kraken & Cydaphex
+repo: Cydaphex/TrackedTargetMarker
+branch: main
+tags: ["PvP", "Combat", "UI"]
+keywords:
+  - target
+  - marker
+  - overhead
+  - assist
+  - tracking
+  - focus
+  - pvp
+  - symbol
+  - arrow
+  - peel


### PR DESCRIPTION
﻿Adds the TrackedTargetMarker addon to the manager.

- Repo: https://github.com/Cydaphex/TrackedTargetMarker
- Release: https://github.com/Cydaphex/TrackedTargetMarker/releases/tag/v4.7
- Authors: Kraken & Cydaphex

Places customizable overhead markers above the targets you track and above those targets'' targets. Independent symbol, color, and size per marker, plus a draggable on-screen toggle button.

Manifest at t/TrackedTargetMarker.yaml; flat repo layout with main.lua in the root.
