### PR TITLE
Add ESCMenu

### DIFF
--- a/e/ESCMenu.yaml
+++ b/e/ESCMenu.yaml
@@ -1,0 +1,15 @@
+name: ESCMenu
+alias: ESCMenu
+description: Rebuilds the ESC menu as retail's category grid, and gives addons a row in it.
+keywords:
+  - esc
+  - menu
+  - retail
+  - ui
+  - interface
+  - settings
+author: Dehling
+repo: DelmonDev/ESCMenu
+branch: main
+kofi: delmon
+tags: ["UI", "QoL"]


### PR DESCRIPTION
Adds ESCMenu — https://github.com/DelmonDev/ESCMenu

Rebuilds AAC's `system_config` popup as the five-column category grid retail
uses, from retail's own sliced artwork, with icon sets for both the dark and
the light client themes. The menu is restyled in place rather than replaced, so
Select Character and Exit Game keep their native handlers.

It also publishes a small lib (`ESCMenu:RegisterAddonBtn`) so other addons can
claim a row in a category of their choosing, and reroutes existing
`michaelClient:AddAddon` entries into the grid without those addons changing
anything.

Released at `1.0.0`. Same author as BetterBars and TrackThatPlease.
