### PR TITLE
Add Norrina-Craft Tracker

### DIFF
--- a/n/norrina_craft_tracker.yaml
+++ b/n/norrina_craft_tracker.yaml
@@ -1,0 +1,18 @@
+name: norrina_craft_tracker
+alias: Norrina-Craft Tracker
+description: Tracks materials for multiple crafting projects and compares the required quantities with the character's current inventory.
+author: Norrina
+repo: r3d3r1c/norrina-craft-tracker
+branch: main
+tags:
+  - QoL
+  - Inventory
+  - Economy
+keywords:
+  - crafting
+  - materials
+  - tracker
+  - inventory
+  - projects
+  - recipes
+


### PR DESCRIPTION
Adds Norrina-Craft Tracker, an inventory-based crafting project tracker for ArcheAge Classic.

Features:
- Multiple persistent crafting projects
- Manual material and quantity tracking
- Exact inventory stack counting
- Live CRAFTABLE / MATERIALS MISSING status updates
- No automation, macros, cursor control, or automatic item placement

Version 1.0.2 has been tested in game.

Repository: https://github.com/r3d3r1c/norrina-craft-tracker
Release: https://github.com/r3d3r1c/norrina-craft-tracker/releases/tag/1.0.2